### PR TITLE
decode: Remove inline hint on table_walk()

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -31,7 +31,7 @@ typedef enum DecodeMode DecodeMode;
 #define ENTRY_TABLE_ROOT 8
 #define ENTRY_MASK 7
 
-static inline unsigned
+static unsigned
 table_walk(unsigned cur_idx, unsigned entry_idx, unsigned* out_kind) {
     static __attribute__((aligned(16))) const uint16_t _decode_table[] = {
 #define FD_DECODE_TABLE_DATA


### PR DESCRIPTION
To avoid GCC warnings when building with `-Os`:

    warning: inlining failed in call to 'table_walk': call is
        unlikely and code size would grow [-Winline]

I don't know if this causes a performance regression when optimizing for
speed instead of size, but perhaps there's a different way we can help
the compiler make this decision in such cases.

(Not really sure what the correct fix is here, so opened this as a draft PR.)