### PR TITLE
encode: Fix OPC_*_MSK on 32-bit systems

### DIFF
--- a/encode.c
+++ b/encode.c
@@ -31,9 +31,9 @@ enum {
 };
 
 #define OPC_SEG_IDX 31
-#define OPC_SEG_MSK (0x7l << OPC_SEG_IDX)
+#define OPC_SEG_MSK ((uint64_t) 0x7l << OPC_SEG_IDX)
 #define OPC_VEXOP_IDX 34
-#define OPC_VEXOP_MSK (0xfl << OPC_VEXOP_IDX)
+#define OPC_VEXOP_MSK ((uint64_t) 0xfl << OPC_VEXOP_IDX)
 
 static bool op_mem(FeOp op) { return op < 0; }
 static bool op_reg(FeOp op) { return op >= 0; }


### PR DESCRIPTION
Where we'd end up losing the upper bits.

GCC catches this and emits a warning such as:

    warning: result of '7 << 31' requires 35 bits to represent, but
        'long int' only has 32 bits [-Wshift-overflow=]