### PR TITLE
Tiny readme change to use a pointer to instr in `fd_format` example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ int ret = fd_decode(buffer, sizeof(buffer), 64, 0, &instr);
 // Relevant properties of instructions can now be queried using the FD_* macros.
 // Or, we can format the instruction to a string buffer:
 char fmtbuf[64];
-fd_format(instr, fmtbuf, sizeof(fmtbuf));
+fd_format(&instr, fmtbuf, sizeof(fmtbuf));
 // fmtbuf now reads: "xchg r8, rax"
 ```
 


### PR DESCRIPTION
Hope this isn't too trivial of a change, but I thought I might as well just create a PR and let you decide that way :).