### PR TITLE
Encoder: Change `FE_NOREG` to be usable in C++ without extra casting

### DIFF
--- a/fadec-enc.h
+++ b/fadec-enc.h
@@ -30,7 +30,7 @@ typedef int64_t FeOp;
  * encoded instruction will be subtracted during encoding. scale must be 1, 2,
  * 4, or 8; but is ignored if  idx == 0. **/
 #define FE_MEM(base,sc,idx,off) (INT64_MIN | ((int64_t) ((base) & 0xfff) << 32) | ((int64_t) ((idx) & 0xfff) << 44) | ((int64_t) ((sc) & 0xf) << 56) | ((off) & 0xffffffff))
-#define FE_NOREG 0
+#define FE_NOREG ((FeReg) 0)
 
 /** Add segment override prefix. This may or may not generate prefixes for the
  * ignored prefixes ES/CS/DS/SS in 64-bit mode. **/


### PR DESCRIPTION
Only affects API v1 of the encoder, as v2 doesn't have this problem.

Even though this shouldn't change semantics, I still ran the tests on my machine (x86-64, Zen1 if that is relevant), they passed both with a debug, and a release build.