### PR TITLE
parseinstrs: Remove `ByteString` import

### DIFF
--- a/parseinstrs.py
+++ b/parseinstrs.py
@@ -7,7 +7,7 @@ from enum import Enum
 from itertools import product
 import re
 import struct
-from typing import NamedTuple, FrozenSet, List, Tuple, Union, Optional, ByteString
+from typing import NamedTuple, FrozenSet, List, Tuple, Union, Optional
 
 INSTR_FLAGS_FIELDS, INSTR_FLAGS_SIZES = zip(*[
     ("modrm_idx", 2),


### PR DESCRIPTION
`ByteString` was deprecated since Python 3.12 and was removed in Python 3.14.[0] It also wasn't actually used in this module.

[0] https://docs.python.org/3/library/collections.abc.html#collections.abc.ByteString